### PR TITLE
fix(modules/security_profiles): Update vulnerability profile 'time_track_by' setting validation

### DIFF
--- a/modules/security_profiles/variables.tf
+++ b/modules/security_profiles/variables.tf
@@ -603,7 +603,7 @@ variable "vulnerability_protection_profiles" {
   validation {
     condition = alltrue([
       for profile in var.vulnerability_protection_profiles : alltrue([
-        for exception in profile.exceptions : contains(["source", "destination", "source-and-destination"], exception.time_track_by)
+        for exception in profile.exceptions : contains(["source", "destination", "source-and-destination"], coalesce(exception.time_track_by, "source"))
       ])
     ])
     error_message = "Valid 'time_track_by' values are: 'source', 'destination', 'source-and-destination'."


### PR DESCRIPTION
## Description

When optional `time_track_by` setting is not specified for an exception, variable validation fails as below during tf plan:

```
│ Error: Invalid function argument
│ 
│   on ../modules/security_profiles/variables.tf line 606, in variable "vulnerability_protection_profiles":
│  606:         for exception in profile.exceptions : contains(["source", "destination", "source-and-destination"], exception.time_track_by)
│     ├────────────────
│     │ exception.time_track_by is null
│ 
│ Invalid value for "value" parameter: argument must not be null.
```

## Motivation and Context

Bug fix

## How Has This Been Tested?

Run plan on on data with exceptions.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
