### PR TITLE
fix(modules/interfaces): Create vr/zone entry only when required

### DIFF
--- a/modules/interfaces/main.tf
+++ b/modules/interfaces/main.tf
@@ -154,7 +154,7 @@ resource "panos_tunnel_interface" "this" {
 }
 
 resource "panos_virtual_router_entry" "this" {
-  for_each = { for k, v in var.interfaces : "${v.virtual_router}_${k}" => { interface = k, virtual_router = v.virtual_router } }
+  for_each = { for k, v in var.interfaces : "${v.virtual_router}_${k}" => { interface = k, virtual_router = v.virtual_router } if try(v.virtual_router, null) != null }
 
   template       = var.mode_map[var.mode] == 0 ? (var.template_stack == "" ? var.template : null) : null
   template_stack = var.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null
@@ -177,7 +177,7 @@ resource "panos_virtual_router_entry" "this" {
 }
 
 resource "panos_zone_entry" "this" {
-  for_each = { for k, v in var.interfaces : "${v.zone}_${k}" => { interface = k, zone = v.zone, vsys = v.vsys } }
+  for_each = { for k, v in var.interfaces : "${v.zone}_${k}" => { interface = k, zone = v.zone, vsys = v.vsys } if try(v.zone, null) != null }
 
   template       = var.mode_map[var.mode] == 0 ? (var.template_stack == "" ? var.template : null) : null
   template_stack = var.mode_map[var.mode] == 0 ? var.template_stack == "" ? null : var.template_stack : null


### PR DESCRIPTION
## Description

When `virtual_router`/`zone` is not specified for an interface (for example association is managed under `virtual_routers` or `zones` module), tf plan fails with an error as below:

```
│ Error: Invalid template interpolation value
│ 
│   on ../modules/interfaces/main.tf line 157, in resource "panos_virtual_router_entry" "this":
│  157:   for_each = { for k, v in var.interfaces : "${v.virtual_router}_${k}" => { interface = k, virtual_router = v.virtual_router } }
│     ├────────────────
│     │ v.virtual_router is null
│ 
│ The expression result is null. Cannot include a null value in a string template.
```

Bug introduced in #41 

## Motivation and Context

Bug fix

## How Has This Been Tested?

Run plan on prepared data

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
