### PR TITLE
feat(modules/addresses): Bulk mode using 'panos_address_objects' resource

### DIFF
--- a/examples/basic_configuration_example/README.md
+++ b/examples/basic_configuration_example/README.md
@@ -4,37 +4,41 @@ This folder shows an example of Terraform code and HCL files that deploy configu
 
 ## Usage
 
-1. Create credential file. In `terraform.tfvars` the path with credentials is ``./creds/credentials.json`` and file structure should look like:
-```json
-{
-    "hostname": "IP_ADDRESS",
-    "username": "ACCOUNT_NAME",
-    "password": "PASSWORD"
-}
-```
+1. Configure credentials and target system address. In this example they are provided using panos provider JSON configuration file that is provided using `panos_config_file` variable. Relevant arguments are as follows:
 
-or using API keys:
+    - for username/password authentication:
 
-```json
-{
-    "hostname": "IP_ADDRESS",
-    "api_key": "API_KEY"
-}
-```
+    ```json
+    {
+        "hostname": "ADDRESS",
+        "username": "ACCOUNT_NAME",
+        "password": "PASSWORD"
+    }
+    ```
 
-where `API_KEY` was generated from as [described in PAN-OS API Guide](https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-panorama-api/get-started-with-the-pan-os-xml-api/get-your-api-key):
+    - for API key authentication:
 
-```
-curl 'https://IP_ADDRESS/api/?type=keygen&user=ACCOUNT_NAME&password=PASSWORD'
-```
+    ```json
+    {
+        "hostname": "ADDRESS",
+        "api_key": "API_KEY"
+    }
+    ```
 
+    The `API_KEY` can be generated as [described in PAN-OS API Guide](https://docs.paloaltonetworks.com/pan-os/10-2/pan-os-panorama-api/get-started-with-the-pan-os-xml-api/get-your-api-key):
+
+    ```
+    $ curl 'https://ADDRESS/api/?type=keygen&user=ACCOUNT_NAME&password=PASSWORD'
+    ```
+
+    For more details regarding available arguments, please refer to [provider documentation](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs#argument-reference).
 
 2. Initialize Terraform and apply changes:
 
-```
-terraform init
-terraform apply
-```
+    ```
+    terraform init
+    terraform apply
+    ```
 
 ## Cleanup
 
@@ -63,6 +67,7 @@ No providers.
 | <a name="module_device_groups"></a> [device\_groups](#module\_device\_groups) | ../../modules/device_groups | n/a |
 | <a name="module_tags"></a> [tags](#module\_tags) | ../../modules/tags | n/a |
 | <a name="module_addresses"></a> [addresses](#module\_addresses) | ../../modules/addresses | n/a |
+| <a name="module_addresses_bulk"></a> [addresses\_bulk](#module\_addresses\_bulk) | ../../modules/addresses | n/a |
 | <a name="module_address_groups"></a> [address\_groups](#module\_address\_groups) | ../../modules/addresses | n/a |
 | <a name="module_services"></a> [services](#module\_services) | ../../modules/services | n/a |
 | <a name="module_service_groups"></a> [service\_groups](#module\_service\_groups) | ../../modules/services | n/a |
@@ -87,12 +92,14 @@ No resources.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_panos_config_file"></a> [panos\_config\_file](#input\_panos\_config\_file) | Path to a JSON configuration file for `panos` provider. | `string` | n/a | yes |
+| <a name="input_panos_timeout"></a> [panos\_timeout](#input\_panos\_timeout) | Timeout in seconds for all provider communication with target system, defaults to `10`. Can also be specified within JSON configuration file. | `number` | `null` | no |
+| <a name="input_mode"></a> [mode](#input\_mode) | Provide information about target. | `string` | `""` | no |
 | <a name="input_device_groups"></a> [device\_groups](#input\_device\_groups) | Used if `var.mode` is panorama, this defines the Device Group for the deployment | `any` | `{}` | no |
 | <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `var.mode` is ngfw, this defines the vsys for the deployment | `string` | `"vsys1"` | no |
-| <a name="input_pan_creds"></a> [pan\_creds](#input\_pan\_creds) | Path to file with credentials to Panorama | `string` | n/a | yes |
-| <a name="input_mode"></a> [mode](#input\_mode) | Provide information about target. | `string` | `""` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags object | `any` | `{}` | no |
-| <a name="input_addresses"></a> [addresses](#input\_addresses) | Address object | `any` | `{}` | no |
+| <a name="input_addresses"></a> [addresses](#input\_addresses) | Address objects to manage using 'addresses' module's individual mode. | `any` | `{}` | no |
+| <a name="input_addresses_bulk"></a> [addresses\_bulk](#input\_addresses\_bulk) | Address objects to manage using 'addresses' module's bulk mode. | `any` | `{}` | no |
 | <a name="input_address_groups"></a> [address\_groups](#input\_address\_groups) | Address groups object | `any` | `{}` | no |
 | <a name="input_services"></a> [services](#input\_services) | Services object | `any` | `{}` | no |
 | <a name="input_service_groups"></a> [service\_groups](#input\_service\_groups) | Service groups object | `any` | `{}` | no |
@@ -119,6 +126,7 @@ No resources.
 | <a name="output_device_groups"></a> [device\_groups](#output\_device\_groups) | n/a |
 | <a name="output_tags"></a> [tags](#output\_tags) | n/a |
 | <a name="output_addresses"></a> [addresses](#output\_addresses) | n/a |
+| <a name="output_addresses_bulk"></a> [addresses\_bulk](#output\_addresses\_bulk) | n/a |
 | <a name="output_address_groups"></a> [address\_groups](#output\_address\_groups) | n/a |
 | <a name="output_services"></a> [services](#output\_services) | n/a |
 | <a name="output_service_groups"></a> [service\_groups](#output\_service\_groups) | n/a |

--- a/examples/basic_configuration_example/main.tf
+++ b/examples/basic_configuration_example/main.tf
@@ -25,6 +25,18 @@ module "addresses" {
   depends_on = [module.tags, module.device_groups]
 }
 
+module "addresses_bulk" {
+  for_each = var.device_groups
+  source   = "../../modules/addresses"
+  mode     = var.mode
+
+  device_group        = each.key
+  address_objects     = var.addresses_bulk
+  addresses_bulk_mode = true
+
+  depends_on = [module.tags, module.device_groups]
+}
+
 module "address_groups" {
   for_each = var.device_groups
   source   = "../../modules/addresses"

--- a/examples/basic_configuration_example/outputs.tf
+++ b/examples/basic_configuration_example/outputs.tf
@@ -17,6 +17,12 @@ output "addresses" {
   )])
 }
 
+output "addresses_bulk" {
+  value = flatten([for k, v in module.addresses_bulk : concat(
+    [for a in v.addresses : { "device_group" : k, "addresses" : a.object[*].name, "id" : a.id }]
+  )])
+}
+
 output "address_groups" {
   value = flatten([for k, v in module.address_groups : concat(
     [for zk, zv in v.address_groups : { "device_group" : k, "address_group" : zk, "id" : zv.id }],

--- a/examples/basic_configuration_example/terraform.tfvars
+++ b/examples/basic_configuration_example/terraform.tfvars
@@ -1,5 +1,6 @@
-pan_creds = "./creds/credentials.json"
-mode      = "panorama"
+panos_config_file = "panos-config.json"
+panos_timeout     = 30
+mode              = "panorama"
 
 ### Device group
 
@@ -66,26 +67,6 @@ tags = {
 ### Address, Address Groups
 
 addresses = {
-  DNS1 = {
-    "value"       = "1.1.1.1/32"
-    "type"        = "ip-netmask"
-    "description" = "DNS-SRV-Public-1"
-  },
-  DNS2 = {
-    "value"       = "1.0.0.1/32"
-    "type"        = "ip-netmask"
-    "description" = "DNS-SRV-Public-2"
-  },
-  DNS3 = {
-    "value"       = "8.8.4.4/32"
-    "type"        = "ip-netmask"
-    "description" = "DNS-GOOGLE-1"
-  },
-  DNS4 = {
-    "value"       = "8.8.8.8/32"
-    "type"        = "ip-netmask"
-    "description" = "DNS-GOOGLE-2"
-  },
   Server10 = {
     "value"       = "10.0.0.10/32"
     "type"        = "ip-netmask"
@@ -118,14 +99,6 @@ addresses = {
     "value" = "10.0.0.0/8"
     "type"  = "ip-netmask"
   },
-  NTP1 = {
-    "value" = "1.0.0.1/32"
-    "type"  = "ip-netmask"
-  },
-  NTP2 = {
-    "value" = "2.0.0.2/32"
-    "type"  = "ip-netmask"
-  },
   "AWS-15.177.0.0_16" = {
     "value" = "15.177.0.0/16"
     "type"  = "ip-netmask"
@@ -140,6 +113,37 @@ addresses = {
   },
   "GlobalProtect Public-C" = {
     "value" = "10.184.2.0/24"
+    "type"  = "ip-netmask"
+  },
+}
+
+addresses_bulk = {
+  DNS1 = {
+    "value"       = "1.1.1.1/32"
+    "type"        = "ip-netmask"
+    "description" = "DNS-SRV-Public-1"
+  },
+  DNS2 = {
+    "value"       = "1.0.0.1/32"
+    "type"        = "ip-netmask"
+    "description" = "DNS-SRV-Public-2"
+  },
+  DNS3 = {
+    "value"       = "8.8.4.4/32"
+    "type"        = "ip-netmask"
+    "description" = "DNS-GOOGLE-1"
+  },
+  DNS4 = {
+    "value"       = "8.8.8.8/32"
+    "type"        = "ip-netmask"
+    "description" = "DNS-GOOGLE-2"
+  },
+  NTP1 = {
+    "value" = "1.0.0.1/32"
+    "type"  = "ip-netmask"
+  },
+  NTP2 = {
+    "value" = "2.0.0.2/32"
     "type"  = "ip-netmask"
   },
 }

--- a/examples/basic_configuration_example/variables.tf
+++ b/examples/basic_configuration_example/variables.tf
@@ -1,3 +1,20 @@
+variable "panos_config_file" {
+  description = "Path to a JSON configuration file for `panos` provider."
+  type        = string
+}
+
+variable "panos_timeout" {
+  description = "Timeout in seconds for all provider communication with target system, defaults to `10`. Can also be specified within JSON configuration file."
+  default     = null
+  type        = number
+}
+
+variable "mode" {
+  description = "Provide information about target."
+  default     = ""
+  type        = string
+}
+
 variable "device_groups" {
   description = "Used if `var.mode` is panorama, this defines the Device Group for the deployment"
   default     = {}
@@ -10,17 +27,6 @@ variable "vsys" {
   type        = string
 }
 
-variable "pan_creds" {
-  description = "Path to file with credentials to Panorama"
-  type        = string
-}
-
-variable "mode" {
-  description = "Provide information about target."
-  default     = ""
-  type        = string
-}
-
 variable "tags" {
   description = "Tags object"
   default     = {}
@@ -28,7 +34,13 @@ variable "tags" {
 }
 
 variable "addresses" {
-  description = "Address object"
+  description = "Address objects to manage using 'addresses' module's individual mode."
+  default     = {}
+  type        = any
+}
+
+variable "addresses_bulk" {
+  description = "Address objects to manage using 'addresses' module's bulk mode."
   default     = {}
   type        = any
 }

--- a/examples/basic_configuration_example/versions.tf
+++ b/examples/basic_configuration_example/versions.tf
@@ -9,5 +9,6 @@ terraform {
 }
 
 provider "panos" {
-  json_config_file = var.pan_creds
+  json_config_file = var.panos_config_file
+  timeout          = var.panos_timeout
 }

--- a/modules/addresses/README.md
+++ b/modules/addresses/README.md
@@ -2,6 +2,13 @@ Palo Alto Networks PAN-OS Address Module
 ---
 This Terraform module allows users to configure address objects and address groups.
 
+For address objects, there are two options to use this module:
+- individual mode - create one `panos_address_obect` resource per object
+- bulk mode - create one `panos_address_obects` resource with multiple objects within
+
+Behaviour is controlled using `var.addresses_bulk_mode` - when set to `false` (default), individual mode is used, otherwise - bulk mode.
+Please see additional considerations when using the bulk mode - like recommended provider settings, terraform performance or lack of "import" capability in `panos_address_obects` resource [documentation](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_objects).
+
 Usage
 ---
 
@@ -80,6 +87,7 @@ No modules.
 |------|------|
 | [panos_address_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_group) | resource |
 | [panos_address_object.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_object) | resource |
+| [panos_address_objects.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/address_objects) | resource |
 | [panos_panorama_address_group.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/panorama_address_group) | resource |
 
 ### Inputs
@@ -88,10 +96,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
 | <a name="input_mode_map"></a> [mode\_map](#input\_mode\_map) | The mode to use for the modules. Valid values are `panorama` and `ngfw`. | <pre>object({<br>    panorama = number<br>    ngfw     = number<br>  })</pre> | <pre>{<br>  "ngfw": 1,<br>  "panorama": 0<br>}</pre> | no |
-| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if _mode_ is panorama, this defines the Device Group for the deployment | `string` | `"shared"` | no |
-| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if _mode_ is ngfw, this defines the vsys for the deployment | `string` | `"vsys1"` | no |
-| <a name="input_address_objects"></a> [address\_objects](#input\_address\_objects) | Map of the address objects, where key is the address object's name:<br>- `type`: (optional) The type of address object. This can be ip-netmask (default), ip-range, fqdn, or ip-wildcard (PAN-OS 9.0+).<br>- `value`: (required) The address object's value. This can take various forms depending on what type of address object this is, but can be something like 192.168.80.150 or 192.168.80.0/24.<br>- `description`: (optional) The description of the address object.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<pre>{<br>  DNS-TAGS-1 = {<br>    value       = "1.1.1.1/32"<br>    type        = "ip-netmask"<br>    description = "DNS Server 1"<br>    tags        = ["DNS-SRV"]<br>  },<br>  PA-UPDATES = {<br>    type        = "fqdn"<br>    value       = "updates.paloaltonetworks.com"<br>    description = "Palo Alto updates"<br>  },<br>  NTP-RANGE-1 = {<br>    name  = "ntp1"<br>    type  = "ip-range"<br>    value = "10.0.0.2-10.0.0.10"<br>  }<br>}</pre> | <pre>map(object({<br>    type        = optional(string, "ip-netmask")<br>    value       = string<br>    description = optional(string)<br>    tags        = optional(list(string))<br>  }))</pre> | `{}` | no |
-| <a name="input_address_groups"></a> [address\_groups](#input\_address\_groups) | Map of the address group objects, where key is the address group's name:<br>- `members`: (optional) The address objects to include in this statically defined address group.<br>- `dynamic_match`: (optional) The IP tags to include in this DAG. Inputs are structured as follows `'<tag name>' and ...` or `'<tag name>' or ...` or mix both `and`/`or`.<br>- `description`: (optional) The description of the address group.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<pre>{<br>  AddressDeviceGroup = {<br>    members     = ["DNS1", "DNS2"]<br>    description = "DNS servers"<br>  }<br>  grp-dns-proxy = {<br>    dynamic_match = "dns-proxy'"<br>  }<br>}</pre> | <pre>map(object({<br>    members       = optional(list(string))<br>    dynamic_match = optional(string)<br>    description   = optional(string)<br>    tags          = optional(list(string))<br>  }))</pre> | `{}` | no |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if `var.mode` is `panorama`, defines the device group for the objects. | `string` | `"shared"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `var.mode` is `ngfw`, defines the vsys for the objects. | `string` | `"vsys1"` | no |
+| <a name="input_addresses_bulk_mode"></a> [addresses\_bulk\_mode](#input\_addresses\_bulk\_mode) | Determines whether each address object is managed as a separate `panos_address_object` resource (when set to `false`) or all within a single `panos_address_objects` resource that is dedicated for bulk operations. | `bool` | `false` | no |
+| <a name="input_address_objects"></a> [address\_objects](#input\_address\_objects) | Map of the address objects, where key is the address object's name:<br>- `type`: (optional) The type of address object. This can be ip-netmask (default), ip-range, fqdn, or ip-wildcard (PAN-OS 9.0+).<br>- `value`: (required) The address object's value. This can take various forms depending on what type of address object this is, but can be something like 192.168.80.150 or 192.168.80.0/24.<br>- `description`: (optional) The description of the address object.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<pre>{<br>  DNS-TAGS-1 = {<br>    value       = "1.1.1.1/32"<br>    type        = "ip-netmask"<br>    description = "DNS Server 1"<br>    tags        = ["DNS-SRV"]<br>  },<br>  PA-UPDATES = {<br>    type        = "fqdn"<br>    value       = "updates.paloaltonetworks.com"<br>    description = "Palo Alto updates"<br>  },<br>  NTP-RANGE-1 = {<br>    name  = "ntp1"<br>    type  = "ip-range"<br>    value = "10.0.0.2-10.0.0.10"<br>  }<br>}</pre> | <pre>map(object({<br>    value       = string<br>    type        = optional(string, "ip-netmask")<br>    description = optional(string)<br>    tags        = optional(list(string))<br>  }))</pre> | `{}` | no |
+| <a name="input_address_groups"></a> [address\_groups](#input\_address\_groups) | Map of the address group objects, where key is the address group's name:<br>- `members`: (optional) The address objects to include in this statically defined address group.<br>- `dynamic_match`: (optional) The IP tags to include in this DAG. Inputs are structured as follows `'<tag name>' and ...` or `<tag name>` or ...`.<br>- `description`: (optional) The description of the address group.<br>- `tags`: (optional) List of administrative tags.<br><br>Example:<br>`<pre>{<br>  AddressDeviceGroup = {<br>    members     = ["DNS1", "DNS2"]<br>    description = "DNS servers"<br>  }<br>  grp-dns-proxy = {<br>    dynamic_match = "dns-proxy'"<br>  }<br>}</pre> | <pre>map(object({<br>    members       = optional(list(string))<br>    dynamic_match = optional(string)<br>    description   = optional(string)<br>    tags          = optional(list(string))<br>  }))</pre> | `{}` | no |
 
 ### Outputs
 

--- a/modules/addresses/outputs.tf
+++ b/modules/addresses/outputs.tf
@@ -1,5 +1,5 @@
 output "addresses" {
-  value = panos_address_object.this
+  value = var.addresses_bulk_mode ? panos_address_objects.this : panos_address_object.this
 }
 
 output "address_groups" {

--- a/modules/addresses/variables.tf
+++ b/modules/addresses/variables.tf
@@ -21,15 +21,21 @@ variable "mode_map" {
 }
 
 variable "device_group" {
-  description = "Used if _mode_ is panorama, this defines the Device Group for the deployment"
+  description = "Used if `var.mode` is `panorama`, defines the device group for the objects."
   default     = "shared"
   type        = string
 }
 
 variable "vsys" {
-  description = "Used if _mode_ is ngfw, this defines the vsys for the deployment"
+  description = "Used if `var.mode` is `ngfw`, defines the vsys for the objects."
   default     = "vsys1"
   type        = string
+}
+
+variable "addresses_bulk_mode" {
+  description = "Determines whether each address object is managed as a separate `panos_address_object` resource (when set to `false`) or all within a single `panos_address_objects` resource that is dedicated for bulk operations."
+  default     = false
+  type        = bool
 }
 
 variable "address_objects" {
@@ -64,8 +70,8 @@ variable "address_objects" {
   EOF
   default     = {}
   type = map(object({
-    type        = optional(string, "ip-netmask")
     value       = string
+    type        = optional(string, "ip-netmask")
     description = optional(string)
     tags        = optional(list(string))
   }))
@@ -79,7 +85,7 @@ variable "address_groups" {
   description = <<-EOF
   Map of the address group objects, where key is the address group's name:
   - `members`: (optional) The address objects to include in this statically defined address group.
-  - `dynamic_match`: (optional) The IP tags to include in this DAG. Inputs are structured as follows `'<tag name>' and ...` or `'<tag name>' or ...` or mix both `and`/`or`.
+  - `dynamic_match`: (optional) The IP tags to include in this DAG. Inputs are structured as follows `'<tag name>' and ...` or `<tag name>` or ...`.
   - `description`: (optional) The description of the address group.
   - `tags`: (optional) List of administrative tags.
 


### PR DESCRIPTION
## Description

Extend `addresses` module to allow creating multiple addresses using `panos_address_objects` resource, that is designed for bulk operations.

## Motivation and Context

Allow for deployment time optimization in situations where large amount of addresses is being managed.

## How Has This Been Tested?

Added sample usage in existing example and deployed.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
