### PR TITLE
feat: New security_policy module and example code

### DIFF
--- a/examples/basic_configuration_example/README.md
+++ b/examples/basic_configuration_example/README.md
@@ -74,6 +74,7 @@ No providers.
 | <a name="module_ipsec"></a> [ipsec](#module\_ipsec) | ../../modules/ipsec | n/a |
 | <a name="module_templates"></a> [templates](#module\_templates) | ../../modules/templates | n/a |
 | <a name="module_template_stacks"></a> [template\_stacks](#module\_template\_stacks) | ../../modules/template_stacks | n/a |
+| <a name="module_security_policies_post_rules"></a> [security\_policies\_post\_rules](#module\_security\_policies\_post\_rules) | ../../modules/security_policy | n/a |
 | <a name="module_security_rule_groups"></a> [security\_rule\_groups](#module\_security\_rule\_groups) | ../../modules/security_rule_groups | n/a |
 | <a name="module_nat_policies"></a> [nat\_policies](#module\_nat\_policies) | ../../modules/nat_policies | n/a |
 | <a name="module_security_profiles"></a> [security\_profiles](#module\_security\_profiles) | ../../modules/security_profiles | n/a |
@@ -98,6 +99,7 @@ No resources.
 | <a name="input_service_groups"></a> [service\_groups](#input\_service\_groups) | Service groups object | `any` | `{}` | no |
 | <a name="input_security_profiles"></a> [security\_profiles](#input\_security\_profiles) | Map with security profiles. | `any` | `{}` | no |
 | <a name="input_log_forwarding_profiles_shared"></a> [log\_forwarding\_profiles\_shared](#input\_log\_forwarding\_profiles\_shared) | Map with log forwarding profiles. | `any` | `{}` | no |
+| <a name="input_security_post_rules"></a> [security\_post\_rules](#input\_security\_post\_rules) | List with security post rules. | `any` | `[]` | no |
 | <a name="input_security_rule_groups"></a> [security\_rule\_groups](#input\_security\_rule\_groups) | Security rule groups | `any` | `{}` | no |
 | <a name="input_nat_policies"></a> [nat\_policies](#input\_nat\_policies) | Security policies | `any` | `{}` | no |
 | <a name="input_interfaces"></a> [interfaces](#input\_interfaces) | n/a | `any` | n/a | yes |

--- a/examples/basic_configuration_example/main.tf
+++ b/examples/basic_configuration_example/main.tf
@@ -172,6 +172,15 @@ module "template_stacks" {
   depends_on = [module.templates]
 }
 
+module "security_policies_post_rules" {
+  for_each = var.device_groups
+  source   = "../../modules/security_policy"
+  mode     = var.mode
+
+  device_group = each.key
+  rulebase     = "post-rulebase"
+  rules        = var.security_post_rules
+}
 
 module "security_rule_groups" {
   for_each = var.device_groups

--- a/examples/basic_configuration_example/terraform.tfvars
+++ b/examples/basic_configuration_example/terraform.tfvars
@@ -40,6 +40,7 @@ tags = {
     comment = "Tag for DNS servers-2"
   }
   "Managed by Terraform" = {
+    color   = "Blue Violet"
     comment = "Managed by Terraform"
   }
   Outbound = {
@@ -228,6 +229,17 @@ service_groups = {
 }
 
 ### Security policies
+security_post_rules = [
+  {
+    name         = "default-deny-telnet"
+    action       = "deny"
+    applications = ["telnet"]
+    tags = [
+      "Outbound",
+      "Managed by Terraform"
+    ]
+  }
+]
 
 security_rule_groups = {
   "allow_rule_group" = {

--- a/examples/basic_configuration_example/variables.tf
+++ b/examples/basic_configuration_example/variables.tf
@@ -63,6 +63,12 @@ variable "log_forwarding_profiles_shared" {
   type        = any
 }
 
+variable "security_post_rules" {
+  description = "List with security post rules."
+  default     = []
+  type        = any
+}
+
 variable "security_rule_groups" {
   description = "Security rule groups"
   default     = {}

--- a/modules/security_policy/README.md
+++ b/modules/security_policy/README.md
@@ -1,0 +1,172 @@
+Palo Alto Networks PAN-OS security policy module
+---
+This Terraform module allows users to configure a **complete** security policy within specified Virtual System (when target device is a firewall) or Devive Group/Rulebase pair (when target device is Panorama). Target device is determined by `mode` variable.
+
+:warning: Input configuration for the module determines full security posture within the specified scope - vsys or device group/rulebase pair. `panos_security_policy` resource used by the module enforces both the contents of individual rules as well as their ordering, any existing rule that does not exist in the input configuration will be removed.
+
+Usage
+---
+
+1. Create a **"main.tf"** file with the following content:
+
+```terraform
+module "security_policy" {
+  source  = "PaloAltoNetworks/terraform-panos-ngfw-modules//modules/security_policy"
+
+  mode = "panorama" # If you want to use this module with a firewall, change this to "ngfw"
+
+  device_group      = "test"
+  rulebase          = "pre-rulebase"
+  rules = [
+    {
+      name = "Allow access to DNS Servers"
+      tags = [
+        "Outbound",
+        "Managed by Terraform"
+      ]
+      source_zones          = ["Trust-L3"]
+      source_addresses      = ["RFC1918_Subnets"]
+      destination_zones     = ["Untrust-L3"]
+      destination_addresses = ["DNS-Servers"]
+      applications          = ["dns"]
+      services              = ["application-default"]
+      action                = "allow"
+      log_end               = "true"
+      virus                 = "default"
+      spyware               = "default"
+      vulnerability         = "default"
+    },
+    {
+      name             = "Allow access to RFC1918"
+      tags             = ["Managed by Terraform"]
+      source_zones     = ["Trust-L3"]
+      source_addresses = ["RFC1918_Subnets"]
+      destination_zones = [
+        "Trust-L3",
+        "Untrust-L3"
+      ]
+      destination_addresses = ["RFC1918_Subnets"]
+      services              = ["application-default"]
+      action                = "allow"
+      log_end               = "true"
+      virus                 = "default"
+      spyware               = "default"
+      vulnerability         = "default"
+    },
+    {
+      name = "Disabled - temporary access to Srv10 and Srv11"
+      tags = [
+        "Outbound",
+        "Managed by Terraform"
+      ]
+      source_zones = ["Trust-L3"]
+      source_addresses = [
+        "Server10",
+        "Server11"
+      ]
+      destination_zones     = ["Untrust-L3"]
+      destination_addresses = ["123.123.123.123/32"]
+      services              = ["SSH-8022"]
+      action                = "allow"
+      log_end               = "true"
+      disabled              = "true"
+      virus                 = "default"
+      spyware               = "default"
+      vulnerability         = "default"
+      url_filtering         = "default"
+      file_blocking         = "basic file blocking"
+      wildfire_analysis     = "default"
+    },
+    {
+      name = "Allow access to SSH Servers"
+      tags = [
+        "Inbound",
+        "Managed by Terraform"
+      ]
+      source_zones          = ["Untrust-L3"]
+      negate_source         = "false"
+      destination_zones     = ["Trust-L3"]
+      destination_addresses = ["SSH-Servers"]
+      negate_destination    = "false"
+      applications          = ["ssh"]
+      services              = ["application-default"]
+      action                = "allow"
+      log_end               = "true"
+    },
+    {
+      name = "Block Some Traffic"
+      tags = [
+        "Outbound",
+        "Managed by Terraform"
+      ]
+      source_zones     = ["Trust-L3"]
+      source_addresses = ["10.0.0.100/32"]
+      action           = "deny"
+      log_end          = "true"
+    }
+  ]
+}
+```
+
+2. Run Terraform
+
+```
+terraform init
+terraform apply
+terraform output
+```
+
+Cleanup
+---
+
+```
+terraform destroy
+```
+
+Compatibility
+---
+This module is meant for use with **PAN-OS >= 10.2** and **Terraform >= 1.4.0**
+
+
+Reference
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+### Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.4.0, < 2.0.0 |
+| <a name="requirement_panos"></a> [panos](#requirement\_panos) | ~> 1.11.1 |
+
+### Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_panos"></a> [panos](#provider\_panos) | ~> 1.11.1 |
+
+### Modules
+
+No modules.
+
+### Resources
+
+| Name | Type |
+|------|------|
+| [panos_security_policy.this](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/security_policy) | resource |
+
+### Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_mode"></a> [mode](#input\_mode) | The mode to use for the module. Valid values are `panorama` and `ngfw`. | `string` | n/a | yes |
+| <a name="input_mode_map"></a> [mode\_map](#input\_mode\_map) | The mode to use for the module. Valid values are `panorama` and `ngfw`. | <pre>object({<br>    panorama = number<br>    ngfw     = number<br>  })</pre> | <pre>{<br>  "ngfw": 1,<br>  "panorama": 0<br>}</pre> | no |
+| <a name="input_device_group"></a> [device\_group](#input\_device\_group) | Used if `mode` is panorama, defines the Device Group for the deployment. | `string` | `"shared"` | no |
+| <a name="input_rulebase"></a> [rulebase](#input\_rulebase) | Used if `mode` is panorama, defines the Rulebase for the policy. | `string` | `"pre-rulebase"` | no |
+| <a name="input_vsys"></a> [vsys](#input\_vsys) | Used if `mode` is ngfw, defines the vsys for the deployment. | `string` | `"vsys1"` | no |
+| <a name="input_rules"></a> [rules](#input\_rules) | List of security rule definitions. The order of the rules will match how they appear in the terraform plan file. Each item supports following parameters:<br>- `name`: (required) The security rule's name.<br>- `description`: (optional) The description of the security rule.<br>- `type`: (optional) Rule type. Valid values are `universal`, `interzone`, or `intrazone` (default: `universal`).<br>- `tags`: (optional) List of administrative tags.<br>- `source_addresses`: (optional) List of source addresses (default: `any`).<br>- `source_zones`: (optional) List of source zones (default: `any`).<br>- `source_users`: (optional) List of source users (default: `any`).<br>- `source_device`: (optional) List of source devices (default: `any`).<br>- `negate_source`: (optional) Boolean designating if the source should be negated (default: `false`).<br>- `hip_profiles`: (optional) List of HIP profiles (default: `any`).<br>- `destination_zones`: (optional) List of destination zones (default: `any`).<br>- `destination_addresses`: (optional) List of destination addresses (default: `any`).<br>- `destination_device`: (optional) List of destination devices (default: `any`).<br>- `negate_destination`: (optional) Boolean designating if the destination should be negated (default: `false`).<br>- `applications`: (optional) List of applications (default: `any`).<br>- `services`: (optional) List of services (default: `application-default`).<br>- `categories`: (optional) List of categories (default: `any`).<br>- `action`: (optional) Action for the matched traffic. Valid values are `allow`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `allow`).<br>- `log_setting`: (optional) Log forwarding profile.<br>- `log_start`: (optional) Boolean designating if log the start of the traffic flow (default: `false`).<br>- `log_end`: (optional) Boolean designating if log the end of the traffic flow (default: `true`).<br>- `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).<br>- `schedule`: (optional) The security rule schedule.<br>- `icmp_unreachable`: (optional) Boolean enabling ICMP unreachable (default: `false`).<br>- `disable_server_response_inspection`: (optional) Boolean disabling server response inspection (default: `false`).<br>- `group`: (optional) Profile setting: `Group` - The group profile name.<br>- `virus`: (optional) Profile setting: `Profiles` - Input the desired antivirus profile name.<br>- `spyware`: (optional) Profile setting: `Profiles` - Input the desired anti-spyware profile name.<br>- `vulnerability`: (optional) Profile setting: `Profiles` - Input the desired vulnerability profile name.<br>- `url_filtering`: (optional) Profile setting: `Profiles` - Input the desired URL filtering profile name.<br>- `file_blocking`: (optional) Profile setting: `Profiles` - Input the desired File-Blocking profile name.<br>- `wildfire_analysis`: (optional) Profile setting: `Profiles` - Input the desired Wildfire Analysis profile name.<br>- `data_filtering`: (optional) Profile setting: `Profiles` - Input the desired Data Filtering profile name.<br>- `audit_comment`: (optional) Comment to apply when the rule is created/updated.<br>- `group_tag`: (optional) Group tag.<br>- `negate_target`: (optional, Panorama only) Instead of applying the rule for the given serial numbers, apply it to everything except them.<br>- `target`: (optional, Panorama only) A target definition,if there are no target sections, then the rule will apply to every vsys of every device in the device group.<br><br>Example:<pre>{<br>  "allow_rule_group" = {<br>    rulebase = "pre-rulebase"<br>    rules = [<br>      {<br>        name = "Allow access to DNS Servers"<br>        tags = [<br>          "Outbound",<br>          "Managed by Terraform"<br>        ]<br>        source_zones                       = ["Trust-L3"]<br>        source_addresses                   = ["RFC1918_Subnets"]<br>        destination_zones                  = ["Untrust-L3"]<br>        destination_addresses              = ["DNS-Servers"]<br>        applications                       = ["dns"]<br>        services                           = ["application-default"]<br>        action                             = "allow"<br>        log_end                            = "true"<br>      },<br>      {<br>        name             = "Allow access to RFC1918"<br>        tags             = ["Managed by Terraform"]<br>        source_zones     = ["Trust-L3"]<br>        source_addresses = ["RFC1918_Subnets"]<br>        destination_zones = [<br>          "Trust-L3",<br>          "Untrust-L3"<br>        ]<br>        destination_addresses              = ["RFC1918_Subnets"]<br>        services                           = ["application-default"]<br>        action                             = "allow"<br>        log_end                            = "true"<br>        virus                              = "default"<br>        spyware                            = "default"<br>        vulnerability                      = "default"<br>      }<br>    ]<br>  }<br>  "block_rule_group" = {<br>    position_keyword = "bottom"<br>    rulebase         = "pre-rulebase"<br>    rules = [<br>      {<br>        name = "Block Some Traffic"<br>        tags = [<br>          "Outbound",<br>          "Managed by Terraform"<br>        ]<br>        source_zones                       = ["Trust-L3"]<br>        source_addresses                   = ["10.0.0.100/32"]<br>        action                             = "deny"<br>        log_end                            = "true"<br>      }<br>    ]<br>  }<br>}</pre> | <pre>list(object({<br>    name                               = string<br>    type                               = optional(string, "universal")<br>    description                        = optional(string)<br>    tags                               = optional(list(string))<br>    source_zones                       = optional(list(string), ["any"])<br>    source_addresses                   = optional(list(string), ["any"])<br>    source_users                       = optional(list(string), ["any"])<br>    source_devices                     = optional(list(string), ["any"])<br>    negate_source                      = optional(string, false)<br>    hip_profiles                       = optional(list(string), ["any"])<br>    destination_zones                  = optional(list(string), ["any"])<br>    destination_addresses              = optional(list(string), ["any"])<br>    destination_devices                = optional(list(string), ["any"])<br>    negate_destination                 = optional(string, false)<br>    applications                       = optional(list(string), ["any"])<br>    services                           = optional(list(string), ["application-default"])<br>    categories                         = optional(list(string), ["any"])<br>    action                             = optional(string, "allow")<br>    log_setting                        = optional(string)<br>    log_start                          = optional(string, false)<br>    log_end                            = optional(string, true)<br>    disabled                           = optional(string, false)<br>    schedule                           = optional(string)<br>    icmp_unreachable                   = optional(string)<br>    disable_server_response_inspection = optional(bool, false)<br>    group                              = optional(string)<br>    virus                              = optional(string)<br>    spyware                            = optional(string)<br>    vulnerability                      = optional(string)<br>    url_filtering                      = optional(string)<br>    file_blocking                      = optional(string)<br>    wildfire_analysis                  = optional(string)<br>    data_filtering                     = optional(string)<br>    audit_comment                      = optional(string)<br>    group_tag                          = optional(string)<br>    negate_target                      = optional(bool, false)<br>    target = optional(list(object({<br>      serial    = string<br>      vsys_list = optional(list(string))<br>    })), null)<br>  }))</pre> | `[]` | no |
+
+### Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_security_policy"></a> [security\_policy](#output\_security\_policy) | n/a |
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/modules/security_policy/main.tf
+++ b/modules/security_policy/main.tf
@@ -1,0 +1,61 @@
+resource "panos_security_policy" "this" {
+
+  device_group = var.mode_map[var.mode] == 0 ? var.device_group : null
+  rulebase     = var.mode_map[var.mode] == 0 ? var.rulebase : null
+  vsys         = var.mode_map[var.mode] == 1 ? var.vsys : null
+
+  dynamic "rule" {
+    for_each = var.rules
+
+    content {
+      name                               = rule.value.name
+      description                        = rule.value.description
+      applications                       = rule.value.applications
+      categories                         = rule.value.categories
+      destination_addresses              = rule.value.destination_addresses
+      destination_zones                  = rule.value.destination_zones
+      destination_devices                = rule.value.destination_devices
+      services                           = rule.value.services
+      source_addresses                   = rule.value.source_addresses
+      source_users                       = rule.value.source_users
+      source_zones                       = rule.value.source_zones
+      source_devices                     = rule.value.source_devices
+      hip_profiles                       = rule.value.hip_profiles
+      tags                               = rule.value.tags
+      type                               = rule.value.type
+      negate_source                      = rule.value.negate_source
+      negate_destination                 = rule.value.negate_destination
+      action                             = rule.value.action
+      log_setting                        = rule.value.log_setting
+      log_start                          = rule.value.log_start
+      log_end                            = rule.value.log_end
+      disabled                           = rule.value.disabled
+      schedule                           = rule.value.schedule
+      icmp_unreachable                   = rule.value.icmp_unreachable
+      disable_server_response_inspection = rule.value.disable_server_response_inspection
+      group                              = rule.value.group
+      virus                              = rule.value.virus
+      spyware                            = rule.value.spyware
+      vulnerability                      = rule.value.vulnerability
+      url_filtering                      = rule.value.url_filtering
+      file_blocking                      = rule.value.file_blocking
+      wildfire_analysis                  = rule.value.wildfire_analysis
+      data_filtering                     = rule.value.data_filtering
+      audit_comment                      = rule.value.audit_comment
+      group_tag                          = rule.value.group_tag
+      negate_target                      = rule.value.negate_target
+
+      dynamic "target" {
+        for_each = try(rule.value.target, null) != null ? { for t in rule.value.target : t.serial => t } : {}
+        content {
+          serial    = target.value.serial
+          vsys_list = target.value.vsys_list
+        }
+      }
+    }
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/modules/security_policy/outputs.tf
+++ b/modules/security_policy/outputs.tf
@@ -1,0 +1,3 @@
+output "security_policy" {
+  value = panos_security_policy.this
+}

--- a/modules/security_policy/variables.tf
+++ b/modules/security_policy/variables.tf
@@ -1,0 +1,202 @@
+variable "mode" {
+  description = "The mode to use for the module. Valid values are `panorama` and `ngfw`."
+  type        = string
+  validation {
+    condition     = contains(["panorama", "ngfw"], var.mode)
+    error_message = "The mode must be either `panorama` or `ngfw`."
+  }
+}
+
+variable "mode_map" {
+  description = "The mode to use for the module. Valid values are `panorama` and `ngfw`."
+  default = {
+    panorama = 0
+    ngfw     = 1
+    # cloud_manager = 2 # Not yet supported
+  }
+  type = object({
+    panorama = number
+    ngfw     = number
+  })
+}
+
+variable "device_group" {
+  description = "Used if `mode` is panorama, defines the Device Group for the deployment."
+  default     = "shared"
+  type        = string
+}
+
+variable "rulebase" {
+  description = "Used if `mode` is panorama, defines the Rulebase for the policy."
+  default     = "pre-rulebase"
+  type        = string
+}
+
+variable "vsys" {
+  description = "Used if `mode` is ngfw, defines the vsys for the deployment."
+  default     = "vsys1"
+  type        = string
+}
+
+#policy
+variable "rules" {
+  description = <<-EOF
+  List of security rule definitions. The order of the rules will match how they appear in the terraform plan file. Each item supports following parameters:
+  - `name`: (required) The security rule's name.
+  - `description`: (optional) The description of the security rule.
+  - `type`: (optional) Rule type. Valid values are `universal`, `interzone`, or `intrazone` (default: `universal`).
+  - `tags`: (optional) List of administrative tags.
+  - `source_addresses`: (optional) List of source addresses (default: `any`).
+  - `source_zones`: (optional) List of source zones (default: `any`).
+  - `source_users`: (optional) List of source users (default: `any`).
+  - `source_device`: (optional) List of source devices (default: `any`).
+  - `negate_source`: (optional) Boolean designating if the source should be negated (default: `false`).
+  - `hip_profiles`: (optional) List of HIP profiles (default: `any`).
+  - `destination_zones`: (optional) List of destination zones (default: `any`).
+  - `destination_addresses`: (optional) List of destination addresses (default: `any`).
+  - `destination_device`: (optional) List of destination devices (default: `any`).
+  - `negate_destination`: (optional) Boolean designating if the destination should be negated (default: `false`).
+  - `applications`: (optional) List of applications (default: `any`).
+  - `services`: (optional) List of services (default: `application-default`).
+  - `categories`: (optional) List of categories (default: `any`).
+  - `action`: (optional) Action for the matched traffic. Valid values are `allow`, `drop`, `reset-client`, `reset-server`, or `reset-both` (default: `allow`).
+  - `log_setting`: (optional) Log forwarding profile.
+  - `log_start`: (optional) Boolean designating if log the start of the traffic flow (default: `false`).
+  - `log_end`: (optional) Boolean designating if log the end of the traffic flow (default: `true`).
+  - `disabled`: (optional) Boolean designating if the security policy rule is disabled (default: `false`).
+  - `schedule`: (optional) The security rule schedule.
+  - `icmp_unreachable`: (optional) Boolean enabling ICMP unreachable (default: `false`).
+  - `disable_server_response_inspection`: (optional) Boolean disabling server response inspection (default: `false`).
+  - `group`: (optional) Profile setting: `Group` - The group profile name.
+  - `virus`: (optional) Profile setting: `Profiles` - Input the desired antivirus profile name.
+  - `spyware`: (optional) Profile setting: `Profiles` - Input the desired anti-spyware profile name.
+  - `vulnerability`: (optional) Profile setting: `Profiles` - Input the desired vulnerability profile name.
+  - `url_filtering`: (optional) Profile setting: `Profiles` - Input the desired URL filtering profile name.
+  - `file_blocking`: (optional) Profile setting: `Profiles` - Input the desired File-Blocking profile name.
+  - `wildfire_analysis`: (optional) Profile setting: `Profiles` - Input the desired Wildfire Analysis profile name.
+  - `data_filtering`: (optional) Profile setting: `Profiles` - Input the desired Data Filtering profile name.
+  - `audit_comment`: (optional) Comment to apply when the rule is created/updated.
+  - `group_tag`: (optional) Group tag.
+  - `negate_target`: (optional, Panorama only) Instead of applying the rule for the given serial numbers, apply it to everything except them.
+  - `target`: (optional, Panorama only) A target definition,if there are no target sections, then the rule will apply to every vsys of every device in the device group.
+
+  Example:
+  ```
+  {
+    "allow_rule_group" = {
+      rulebase = "pre-rulebase"
+      rules = [
+        {
+          name = "Allow access to DNS Servers"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones                       = ["Trust-L3"]
+          source_addresses                   = ["RFC1918_Subnets"]
+          destination_zones                  = ["Untrust-L3"]
+          destination_addresses              = ["DNS-Servers"]
+          applications                       = ["dns"]
+          services                           = ["application-default"]
+          action                             = "allow"
+          log_end                            = "true"
+        },
+        {
+          name             = "Allow access to RFC1918"
+          tags             = ["Managed by Terraform"]
+          source_zones     = ["Trust-L3"]
+          source_addresses = ["RFC1918_Subnets"]
+          destination_zones = [
+            "Trust-L3",
+            "Untrust-L3"
+          ]
+          destination_addresses              = ["RFC1918_Subnets"]
+          services                           = ["application-default"]
+          action                             = "allow"
+          log_end                            = "true"
+          virus                              = "default"
+          spyware                            = "default"
+          vulnerability                      = "default"
+        }
+      ]
+    }
+    "block_rule_group" = {
+      position_keyword = "bottom"
+      rulebase         = "pre-rulebase"
+      rules = [
+        {
+          name = "Block Some Traffic"
+          tags = [
+            "Outbound",
+            "Managed by Terraform"
+          ]
+          source_zones                       = ["Trust-L3"]
+          source_addresses                   = ["10.0.0.100/32"]
+          action                             = "deny"
+          log_end                            = "true"
+        }
+      ]
+    }
+  }
+  ```
+  EOF
+  default     = []
+  type = list(object({
+    name                               = string
+    type                               = optional(string, "universal")
+    description                        = optional(string)
+    tags                               = optional(list(string))
+    source_zones                       = optional(list(string), ["any"])
+    source_addresses                   = optional(list(string), ["any"])
+    source_users                       = optional(list(string), ["any"])
+    source_devices                     = optional(list(string), ["any"])
+    negate_source                      = optional(string, false)
+    hip_profiles                       = optional(list(string), ["any"])
+    destination_zones                  = optional(list(string), ["any"])
+    destination_addresses              = optional(list(string), ["any"])
+    destination_devices                = optional(list(string), ["any"])
+    negate_destination                 = optional(string, false)
+    applications                       = optional(list(string), ["any"])
+    services                           = optional(list(string), ["application-default"])
+    categories                         = optional(list(string), ["any"])
+    action                             = optional(string, "allow")
+    log_setting                        = optional(string)
+    log_start                          = optional(string, false)
+    log_end                            = optional(string, true)
+    disabled                           = optional(string, false)
+    schedule                           = optional(string)
+    icmp_unreachable                   = optional(string)
+    disable_server_response_inspection = optional(bool, false)
+    group                              = optional(string)
+    virus                              = optional(string)
+    spyware                            = optional(string)
+    vulnerability                      = optional(string)
+    url_filtering                      = optional(string)
+    file_blocking                      = optional(string)
+    wildfire_analysis                  = optional(string)
+    data_filtering                     = optional(string)
+    audit_comment                      = optional(string)
+    group_tag                          = optional(string)
+    negate_target                      = optional(bool, false)
+    target = optional(list(object({
+      serial    = string
+      vsys_list = optional(list(string))
+    })), null)
+  }))
+  validation {
+    condition = alltrue([
+      for rule in var.rules :
+      contains(["universal", "interzone", "intrazone"], coalesce(rule.type, "universal"))
+    ])
+    error_message = "Valid types of type are `universal`, `interzone`, `intrazone`"
+  }
+  validation {
+    condition = alltrue([
+      for rule in var.rules :
+      contains([
+        "allow", "deny", "drop", "reset-client", "reset-server", "reset-both"
+      ], coalesce(rule.action, "allow"))
+    ])
+    error_message = "Valid types of action are `allow`, `deny`, `drop`, `reset-client`, `reset-server`, `reset-both`"
+  }
+}

--- a/modules/security_policy/versions.tf
+++ b/modules/security_policy/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.4.0, < 2.0.0"
+  required_providers {
+    panos = {
+      source  = "PaloAltoNetworks/panos"
+      version = "~> 1.11.1"
+    }
+  }
+}


### PR DESCRIPTION
## Description

New module that allows to manage entire security policy posture within vsys (when targeting a firewall) or device group/rulebase (when targeting Panorama) using [panos_security_policy](https://registry.terraform.io/providers/PaloAltoNetworks/panos/latest/docs/resources/security_policy) resource.

Important note - from the resource's documentation:

> This resource manages the full set of security rules in a vsys, enforcing both the contents of individual rules as well as their ordering.
> [...]
> This resource will remove any security rule not defined in this resource.

## Motivation and Context

Allow to define a complete security policy per vsys and device group/rulebase.

## How Has This Been Tested?

Added sample code to existing example and deploy.

## Types of changes

- New feature (non-breaking change which adds functionality)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
