### PR TITLE
fix(modules/ipsec): Fix IKE gateways local/peer id type validation

### DIFF
--- a/modules/ipsec/variables.tf
+++ b/modules/ipsec/variables.tf
@@ -233,12 +233,12 @@ variable "ike_gateways" {
     error_message = "Valid values for IKE gateway version are `ikev1`, `ikev2`, `ikev2-preferred`"
   }
   validation {
-    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], ike_gateway.peer_id_type)])
-    error_message = "Valid values for peer ID type are `ipaddr`, `fqdn`, `ufqdn`, `keyid`, or `dn`"
+    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], coalesce(ike_gateway.peer_id_type, "ipaddr"))])
+    error_message = "If set, valid values for peer ID type are `ipaddr`, `fqdn`, `ufqdn`, `keyid`, or `dn`."
   }
   validation {
-    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], ike_gateway.local_id_type)])
-    error_message = "Valid values for local ID type are `ipaddr`, `fqdn`, `ufqdn`, `keyid`, or `dn`"
+    condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], coalesce(ike_gateway.local_id_type, "ipaddr"))])
+    error_message = "If set, valid values for local ID type are `ipaddr`, `fqdn`, `ufqdn`, `keyid`, or `dn`"
   }
   validation {
     condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["pre-shared-key", "certificate"], ike_gateway.auth_type)])


### PR DESCRIPTION
## Description

Fix validation for `local_id_type` and `peer_id_type` parameters in `ike_gateways` variable.

## Motivation and Context

If one of the value is unset (valid configuration, visible as `None` in the UI) terraform returns errors as below:

```
│ Error: Invalid function argument
│ 
│   on ../modules/ipsec/variables.tf line 237, in variable "ike_gateways":
│  237:     condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn", null], ike_gateway.peer_id_type)])
│     ├────────────────
│     │ ike_gateway.peer_id_type is null
│ 
│ Invalid value for "value" parameter: argument must not be null.
╵
╷
│ Error: Invalid function argument
│ 
│   on ../modules/ipsec/variables.tf line 241, in variable "ike_gateways":
│  241:     condition     = alltrue([for ike_gateway in var.ike_gateways : contains(["ipaddr", "fqdn", "ufqdn", "keyid", "dn"], ike_gateway.local_id_type)])
│     ├────────────────
│     │ ike_gateway.local_id_type is null
│ 
│ Invalid value for "value" parameter: argument must not be null.
```

## How Has This Been Tested?

Plan and apply configurations that have one of the params unspecified.

## Types of changes

- Bug fix (non-breaking change which fixes an issue)

## Checklist

- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes if appropriate.
- [ ] All new and existing tests passed.
